### PR TITLE
Fix compilation with clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Wall -Werror -O -ansi -D_POSIX_C_SOURCE=200809L -g
+CFLAGS = -Wall -Werror -O -std=c99 -D_POSIX_C_SOURCE=200809L -g
 BINS = $(addprefix teerank-,add-new-servers update-servers generate-index update-players update-clans generate-clan-page compute-ranks generate-rank-page generate-about paginate-ranks init-database update)
 CGI = teerank.cgi
 

--- a/src/server.c
+++ b/src/server.c
@@ -89,8 +89,6 @@ int write_server_state(struct server_state *state, char *server_name)
 	FILE *file;
 
 	assert(state != NULL);
-	assert(file != NULL);
-	assert(path != NULL);
 
 	if (!(path = get_path(server_name, "state")))
 		return 0;


### PR DESCRIPTION
Fixes the following errors:

```
clang -Wall -Werror -O -ansi -D_POSIX_C_SOURCE=200809L -g   -c -o src/add-new-servers.o src/add-new-servers.c
clang -Wall -Werror -O -ansi -D_POSIX_C_SOURCE=200809L -g   -c -o src/network.o src/network.c
clang -Wall -Werror -O -ansi -D_POSIX_C_SOURCE=200809L -g   -c -o src/config.o src/config.c
clang -o teerank-add-new-servers -Wall -Werror -O -ansi -D_POSIX_C_SOURCE=200809L -g src/add-new-servers.o src/network.o src/config.o
clang-3.7: error: argument unused during compilation: '-ansi'
Makefile:15: recipe for target 'teerank-add-new-servers' failed
make: *** [teerank-add-new-servers] Error 1
```

```
clang -o teerank-add-new-servers -Wall -Werror -O -std=c99 -D_POSIX_C_SOURCE=200809L -g src/add-new-servers.o src/network.o src/config.o
clang -Wall -Werror -O -std=c99 -D_POSIX_C_SOURCE=200809L -g   -c -o src/update-servers.o src/update-servers.c
clang -Wall -Werror -O -std=c99 -D_POSIX_C_SOURCE=200809L -g   -c -o src/pool.o src/pool.c
clang -Wall -Werror -O -std=c99 -D_POSIX_C_SOURCE=200809L -g   -c -o src/delta.o src/delta.c
clang -Wall -Werror -O -std=c99 -D_POSIX_C_SOURCE=200809L -g   -c -o src/io.o src/io.c
clang -Wall -Werror -O -std=c99 -D_POSIX_C_SOURCE=200809L -g   -c -o src/server.o src/server.c
src/server.c:93:9: error: variable 'path' is uninitialized when used here [-Werror,-Wuninitialized]
        assert(path != NULL);
               ^~~~
/usr/include/assert.h:86:5: note: expanded from macro 'assert'
  ((expr)                                                               \
    ^
src/server.c:88:12: note: initialize the variable 'path' to silence this warning
        char *path;
                  ^
                   = NULL
src/server.c:92:9: error: variable 'file' is uninitialized when used here [-Werror,-Wuninitialized]
        assert(file != NULL);
               ^~~~
/usr/include/assert.h:86:5: note: expanded from macro 'assert'
  ((expr)                                                               \
    ^
src/server.c:89:12: note: initialize the variable 'file' to silence this warning
        FILE *file;
                  ^
                   = NULL
2 errors generated.
<builtin>: recipe for target 'src/server.o' failed
make: *** [src/server.o] Error 1
```
