### PR TITLE
Fix regression in read/write server state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /index.html
 
 *.o
+*.swp
 
 /teerank-add-new-servers
 /teerank-generate-index

--- a/src/server.c
+++ b/src/server.c
@@ -38,8 +38,10 @@ int read_server_state(struct server_state *state, char *server_name)
 	if (!(path = get_path(server_name, "state")))
 		return 0;
 	if (!(file = fopen(path, "r"))) {
-		if (errno != ENOENT)
-			perror(path);
+		if (errno == ENOENT)
+			/* State file has not been created yet */
+			return 1;
+		perror(path);
 		return 0;
 	}
 

--- a/src/server.c
+++ b/src/server.c
@@ -89,8 +89,6 @@ int write_server_state(struct server_state *state, char *server_name)
 	FILE *file;
 
 	assert(state != NULL);
-	assert(file != NULL);
-	assert(path != NULL);
 
 	if (!(path = get_path(server_name, "state")))
 		return 0;


### PR DESCRIPTION
The commit bd0658460bf1dae734953d70955876fdfd159c34 introduced a regression with impossibility to write server state for newly seen servers.
Because server state is first read then written returning 0 if state is not present during read makes it impossible for write to happen therefore effectively blocking any state updates
https://github.com/needs/teerank/commit/bd0658460bf1dae734953d70955876fdfd159c34#diff-0235f01a49d01b35e981a41f59a9d2d6R40

This PR also fixes left-out assertions that weren't removed in the said commit and adds vim generated .swp files in .gitignore.
