### PR TITLE
Add toggle to view past clan members

### DIFF
--- a/apps/frontend/app/clan/[clanName]/PastMembersToggle.tsx
+++ b/apps/frontend/app/clan/[clanName]/PastMembersToggle.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export function PastMembersToggle({ clanName, showPastMembers }: { clanName: string, showPastMembers: boolean }) {
+  const router = useRouter();
+
+  return (
+    <div className="flex justify-end px-8 mb-2">
+      <label className="flex items-center gap-2 text-sm text-[#999999] cursor-pointer">
+        <input 
+          type="checkbox" 
+          checked={showPastMembers} 
+          onChange={(e) => {
+            const url = `/clan/${encodeURIComponent(clanName)}${e.target.checked ? '?past=true' : ''}`;
+            router.replace(url, { scroll: false });
+          }}
+          className="cursor-pointer"
+        />
+        <span className="select-none">Show past members</span>
+      </label>
+    </div>
+  );
+}

--- a/apps/frontend/app/clan/[clanName]/page.tsx
+++ b/apps/frontend/app/clan/[clanName]/page.tsx
@@ -6,7 +6,8 @@ import { PlayerList } from '../../../components/PlayerList';
 import { searchParamPageSchema } from '../../../utils/page';
 import { Metadata } from 'next';
 import { encodeString } from '../../../utils/encoding';
-
+import Link from 'next/link';
+import { PastMembersToggle } from './PastMembersToggle';
 export async function generateMetadata({
   params,
 }: {
@@ -32,16 +33,23 @@ export default async function Index({
 }) {
   const { clanName } = paramsSchema.parse(params);
   const { page } = searchParamPageSchema.parse(searchParams);
+  const showPastMembers = searchParams.past === 'true' || searchParams.past === '1';
 
   const clan = await prisma.clan.findUnique({
     select: {
       activePlayerCount: true,
+      _count: {
+        select: {
+          clanPlayerInfos: true,
+        },
+      },
       clanPlayerInfos: {
         select: {
           playTime: true,
           player: {
             select: {
               name: true,
+              clanName: true,
               lastSeenAt: true,
               gameServerStateClients: {
                 select: {
@@ -61,7 +69,7 @@ export default async function Index({
             },
           },
         },
-        where: {
+        where: showPastMembers ? undefined : {
           player: {
             clanName,
           },
@@ -83,21 +91,25 @@ export default async function Index({
   }
 
   return (
-    <PlayerList
-      playerCount={clan.activePlayerCount}
-      rankMethod={null}
-      showLastSeen={true}
-      players={clan.clanPlayerInfos.map((playerInfo, index) => ({
-        rank: index + 1,
-        name: playerInfo.player.name,
-        clan: clanName,
-        playTime: playerInfo.playTime,
-        lastSeenAt: playerInfo.player.lastSeenAt,
-        gameServers: playerInfo.player.gameServerStateClients.map((client) => ({
-          ip: client.gameServerState.gameServer?.ip ?? '',
-          port: client.gameServerState.gameServer?.port ?? 0,
-        })),
-      }))}
-    />
+    <div className="flex flex-col gap-4">
+      <PastMembersToggle clanName={clanName} showPastMembers={showPastMembers} />
+      <PlayerList
+        playerCount={showPastMembers ? clan._count.clanPlayerInfos : clan.activePlayerCount}
+        rankMethod={null}
+        showLastSeen={true}
+        players={clan.clanPlayerInfos.map((playerInfo, index) => ({
+          rank: index + 1,
+          name: playerInfo.player.name,
+          clan: clanName,
+          isActiveClan: playerInfo.player.clanName === clanName,
+          playTime: playerInfo.playTime,
+          lastSeenAt: playerInfo.player.lastSeenAt,
+          gameServers: playerInfo.player.gameServerStateClients.map((client) => ({
+            ip: client.gameServerState.gameServer?.ip ?? '',
+            port: client.gameServerState.gameServer?.port ?? 0,
+          })),
+        }))}
+      />
+    </div>
   );
 }

--- a/apps/frontend/components/PlayerList.tsx
+++ b/apps/frontend/components/PlayerList.tsx
@@ -15,6 +15,7 @@ export function PlayerList({
     rank: number;
     name: string;
     clan?: string;
+    isActiveClan?: boolean;
     rating?: number;
     playTime: bigint;
     lastSeenAt: Date;
@@ -76,7 +77,8 @@ export function PlayerList({
         <Fragment key={player.name}>
           <ListCell alignRight label={formatInteger(player.rank)} />
           <ListCell
-            label={player.name}
+            label={player.isActiveClan === false ? `${player.name} (Past)` : player.name}
+            className={player.isActiveClan === false ? 'text-gray-400' : ''}
             href={{
               pathname: `/player/${encodeString(player.name)}`,
             }}


### PR DESCRIPTION
Hey! I'm m09l6d0ur13ii, the creator of the clan PandaℳAP. I use your service all the time and recommend it to a lot of people, really love what you've built! 

I added a small feature to the clan page: a toggle to view past clan members. The database already keeps track of historical `ClanPlayerInfo`, so I just added a simple native checkbox above the player list to toggle this view. When checked, it removes the active clan filter and shows the top 100 players from the clan's history sorted by playtime. It uses Next.js `replace` so it doesn't mess up the browser history when you click "Back".

Btw, I noticed that the main site's data hasn't been updating for about 5 months (everyone is stuck at "5 months ago"). When I was running the project locally, the default `masterX.teeworlds.com` UDP servers were returning 0 game servers. I think your worker might be failing there. If you add DDNet master servers (`master1.ddnet.org`, `master2.ddnet.org`, etc.) to your `addDefaultMasterServers.ts`, it completely fixes the issue and the parser starts working perfectly again!

OFF
<img width="1920" height="944" alt="image-q5 (2)" src="https://github.com/user-attachments/assets/0c1c1e62-d70a-40af-874a-a823b9757ecc" />

ON
<img width="1920" height="944" alt="image-q6 (2)" src="https://github.com/user-attachments/assets/a13513d4-0957-4dee-9deb-4b1a7e98a050" />