### PR TITLE
Delete archived clients and snapshots in one transaction

### DIFF
--- a/apps/worker/src/workers/archiveSnapshots.ts
+++ b/apps/worker/src/workers/archiveSnapshots.ts
@@ -138,12 +138,14 @@ async function archiveBatch(snapshots: ArchivableSnapshot[]) {
       throw new Error(`Archive object ${key} is missing or empty, not deleting rows`);
     }
 
-    await prisma.gameServerClient.deleteMany({
-      where: { snapshotId: { gte: firstId, lte: lastId } },
-    });
-    await prisma.gameServerSnapshot.deleteMany({
-      where: { id: { gte: firstId, lte: lastId } },
-    });
+    await prisma.$transaction([
+      prisma.gameServerClient.deleteMany({
+        where: { snapshotId: { gte: firstId, lte: lastId } },
+      }),
+      prisma.gameServerSnapshot.deleteMany({
+        where: { id: { gte: firstId, lte: lastId } },
+      }),
+    ]);
 
     console.log(`Archived ${chunk.length} snapshots to ${key}`);
   }


### PR DESCRIPTION
`archiveBatch` deleted the client rows and the snapshot rows as two separate statements, so a connection drop between them left the clients gone while the snapshots remained — and the next tick would re-read those snapshots with no clients attached and overwrite the object at the same key with a client-less version, silently losing client rows that had already been archived correctly. This wraps both deletes in a single `prisma.$transaction`, keeping clients first to avoid a per-row cascade from the snapshots.

The window is real rather than theoretical: while the backlog drains, roughly 20% of archive jobs are failing on database connection loss, and one of them failed at the client delete specifically. Nothing has been lost yet — I verified that `LastModified` is still monotonic with id across all ~2900 objects in the bucket, so no object has been rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)