### PR TITLE
Deploy to Fly only on pushes to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,82 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      deploy:
+        description: Deploy the built apps to Fly
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npx nx run-many -t lint --parallel=3
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Open database proxy
+        run: |
+          flyctl proxy 5434:5432 --app teerankio-postgres2 &
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_POSTGRES2 }}
+
+      - name: Open redis proxy
+        run: |
+          flyctl proxy 6379:6379 --app teerankio-redis &
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_REDIS }}
+
+      - name: Migrate database
+        run: |
+          sleep 2
+          npx prisma generate --sql --schema=libs/prisma/prisma/schema.prisma
+          npx nx run-many -t prisma-deploy --parallel=4
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_POSTGRES2 }}
+          PRISMA_BINARY_TARGETS: '["native", "linux-musl-openssl-3.0.x", "linux-musl"]'
+
+      - name: Build
+        run: npx nx run-many -t build --configuration=production --parallel=4
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Test
+        run: |
+          npx nx run-many -t test
+        env:
+          PRISMA_BINARY_TARGETS: '["native", "linux-musl-openssl-3.0.x", "linux-musl"]'
+
+      - name: Deploy frontend
+        if: inputs.deploy
+        run: flyctl deploy --config apps/frontend/fly.toml --dockerfile apps/frontend/Dockerfile
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_FRONTEND }}
+          PRISMA_BINARY_TARGETS: '["native", "linux-musl-openssl-3.0.x", "linux-musl"]'
+
+      - name: Deploy worker
+        if: inputs.deploy
+        run: flyctl deploy --config apps/worker/fly.toml --dockerfile apps/worker/Dockerfile
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_WORKER }}
+          PRISMA_BINARY_TARGETS: '["native", "linux-musl-openssl-3.0.x", "linux-musl"]'
+
+      - name: Deploy scheduler
+        if: inputs.deploy
+        run: flyctl deploy --config apps/scheduler/fly.toml --dockerfile apps/scheduler/Dockerfile
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_SCHEDULER }}
+          PRISMA_BINARY_TARGETS: '["native", "linux-musl-openssl-3.0.x", "linux-musl"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,76 +1,14 @@
-name: CI
+name: Deploy
+
 on:
   push:
     branches:
       - master
-  pull_request:
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint
-        run: npx nx run-many -t lint --parallel=3
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Open database proxy
-        run: |
-          flyctl proxy 5434:5432 --app teerankio-postgres2 &
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_POSTGRES2 }}
-
-      - name: Open redis proxy
-        run: |
-          flyctl proxy 6379:6379 --app teerankio-redis &
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_REDIS }}
-
-      - name: Migrate database
-        run: |
-          sleep 2
-          npx prisma generate --sql --schema=libs/prisma/prisma/schema.prisma
-          npx nx run-many -t prisma-deploy --parallel=4
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_POSTGRES2 }}
-          PRISMA_BINARY_TARGETS: '["native", "linux-musl-openssl-3.0.x", "linux-musl"]'
-
-      - name: Build
-        run: npx nx run-many -t build --configuration=production --parallel=4
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-
-      - name: Test
-        run: |
-          npx nx run-many -t test
-        env:
-          PRISMA_BINARY_TARGETS: '["native", "linux-musl-openssl-3.0.x", "linux-musl"]'
-
-      - name: Deploy frontend
-        run: flyctl deploy --config apps/frontend/fly.toml --dockerfile apps/frontend/Dockerfile
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_FRONTEND }}
-          PRISMA_BINARY_TARGETS: '["native", "linux-musl-openssl-3.0.x", "linux-musl"]'
-
-      - name: Deploy worker
-        run: flyctl deploy --config apps/worker/fly.toml --dockerfile apps/worker/Dockerfile
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_WORKER }}
-          PRISMA_BINARY_TARGETS: '["native", "linux-musl-openssl-3.0.x", "linux-musl"]'
-
-      - name: Deploy scheduler
-        run: flyctl deploy --config apps/scheduler/fly.toml --dockerfile apps/scheduler/Dockerfile
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_SCHEDULER }}
-          PRISMA_BINARY_TARGETS: '["native", "linux-musl-openssl-3.0.x", "linux-musl"]'
+  deploy:
+    name: Deploy
+    uses: ./.github/workflows/build.yml
+    with:
+      deploy: true
+    secrets: inherit


### PR DESCRIPTION
The CI workflow ran a single job for both `push` to master and `pull_request`, so the three `flyctl deploy` steps fired on every pull request.

The pipeline now lives in `build.yml` as a `workflow_call` reusable workflow with a `deploy` boolean input that gates the deploy steps; `ci.yml` calls it on `pull_request` and `deploy.yml` calls it with `deploy: true` on push to master. Branch filtering is the `on.push.branches` trigger rather than a `github.ref` comparison, and the pipeline is not duplicated between the two callers.

Note that the `Migrate database` step still runs on pull requests, applying `prisma migrate deploy` against production. That is load-bearing rather than an oversight: the repo uses Prisma typedSql, and `prisma generate --sql` typechecks `libs/prisma/prisma/sql` against a live database, so a PR adding a migration plus a query using it would fail to build if production were not migrated first — fixing it properly needs a scratch database for CI runs.

Since the workflows are renamed, any required status checks pinned to the old `CI / Build` name need updating in branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)