### PR TITLE
Add a time rewind bar to explore past game server snapshots

### DIFF
--- a/apps/frontend/app/api/server/[ip]/[port]/snapshot/[snapshotId]/route.ts
+++ b/apps/frontend/app/api/server/[ip]/[port]/snapshot/[snapshotId]/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { decodeIp } from '../../../../../../../utils/encoding';
+import prisma from '../../../../../../../utils/prisma';
+
+const paramsSchema = z.object({
+  ip: z.string().transform(decodeIp),
+  port: z.coerce.number().int().positive().max(65535),
+  snapshotId: z.coerce.number().int().positive(),
+});
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { ip: string; port: string; snapshotId: string } }
+) {
+  const parsedParams = paramsSchema.safeParse(params);
+
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: 'Bad request' }, { status: 400 });
+  }
+
+  const { ip, port, snapshotId } = parsedParams.data;
+
+  const snapshot = await prisma.gameServerSnapshot.findFirst({
+    where: {
+      id: snapshotId,
+      gameServer: {
+        ip,
+        port,
+      },
+    },
+    select: {
+      id: true,
+      createdAt: true,
+      name: true,
+      numClients: true,
+      maxClients: true,
+      map: {
+        select: {
+          name: true,
+          gameTypeName: true,
+        },
+      },
+      clients: {
+        orderBy: {
+          score: 'desc',
+        },
+        select: {
+          playerName: true,
+          clanName: true,
+          score: true,
+        },
+      },
+    },
+  });
+
+  if (snapshot === null) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(snapshot, {
+    headers: {
+      'Cache-Control': 'public, max-age=86400, immutable',
+    },
+  });
+}

--- a/apps/frontend/app/server/[ip]/[port]/page.tsx
+++ b/apps/frontend/app/server/[ip]/[port]/page.tsx
@@ -6,7 +6,8 @@ import Link from 'next/link';
 import { List, ListCell } from '../../../../components/List';
 import { searchParamPageSchema } from '../../../../utils/page';
 import prisma from '../../../../utils/prisma';
-import { encodeString } from '../../../../utils/encoding';
+import { encodeIp, encodeString } from '../../../../utils/encoding';
+import { SnapshotTimeline } from '../../../../components/SnapshotTimeline';
 import { formatPlayTime } from '../../../../utils/format';
 import { GameServer } from '@prisma/client';
 import { formatDuration, intervalToDuration } from 'date-fns';
@@ -78,33 +79,51 @@ export default async function Index({
 
   const { ip, port } = parsedParams.data;
 
-  const gameServer = await prisma.gameServer.findUnique({
-    where: {
-      ip_port: {
-        ip,
-        port,
-      },
-    },
-    include: {
-      gameServerState: {
-        include: {
-          clients: {
-            orderBy: {
-              score: 'desc',
-            },
-            skip: (page - 1) * 100,
-            take: 100,
-          },
-          _count: {
-            select: {
-              clients: true,
-            },
-          },
-          map: true,
+  const [gameServer, snapshots] = await Promise.all([
+    prisma.gameServer.findUnique({
+      where: {
+        ip_port: {
+          ip,
+          port,
         },
       },
-    },
-  });
+      include: {
+        gameServerState: {
+          include: {
+            clients: {
+              orderBy: {
+                score: 'desc',
+              },
+              skip: (page - 1) * 100,
+              take: 100,
+            },
+            _count: {
+              select: {
+                clients: true,
+              },
+            },
+            map: true,
+          },
+        },
+      },
+    }),
+    prisma.gameServerSnapshot.findMany({
+      where: {
+        gameServer: {
+          ip,
+          port,
+        },
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+      select: {
+        id: true,
+        createdAt: true,
+        numClients: true,
+      },
+    }),
+  ]);
 
   if (gameServer === null) {
     return notFound();
@@ -162,50 +181,61 @@ export default async function Index({
         </section>
       </header>
 
-      <List
-        pageCount={Math.ceil(gameServer.gameServerState._count.clients / 100)}
-        columns={[
-          {
-            title: '',
-            expand: false,
-          },
-          {
-            title: 'Name',
-            expand: true,
-          },
-          {
-            title: 'Clan',
-            expand: true,
-          },
-          {
-            title: 'Score',
-            expand: false,
-          },
-        ]}
+      <SnapshotTimeline
+        snapshots={snapshots.map((snapshot) => ({
+          id: snapshot.id,
+          createdAt: snapshot.createdAt.toISOString(),
+          numClients: snapshot.numClients,
+        }))}
+        apiPath={`/api/server/${encodeIp(gameServer.ip)}/${
+          gameServer.port
+        }/snapshot`}
       >
-        {gameServer.gameServerState.clients.map((client, index) => (
-          <>
-            <ListCell alignRight label={`${index + 1}`} />
-            <ListCell
-              label={client.playerName}
-              href={{
-                pathname: `/player/${encodeString(client.playerName)}`,
-              }}
-            />
-            <ListCell
-              label={client.clanName ?? ''}
-              href={
-                client.clanName === null
-                  ? undefined
-                  : {
-                      pathname: `/clan/${encodeString(client.clanName)}`,
-                    }
-              }
-            />
-            <ListCell alignRight label={client.score.toString()} />
-          </>
-        ))}
-      </List>
+        <List
+          pageCount={Math.ceil(gameServer.gameServerState._count.clients / 100)}
+          columns={[
+            {
+              title: '',
+              expand: false,
+            },
+            {
+              title: 'Name',
+              expand: true,
+            },
+            {
+              title: 'Clan',
+              expand: true,
+            },
+            {
+              title: 'Score',
+              expand: false,
+            },
+          ]}
+        >
+          {gameServer.gameServerState.clients.map((client, index) => (
+            <>
+              <ListCell alignRight label={`${index + 1}`} />
+              <ListCell
+                label={client.playerName}
+                href={{
+                  pathname: `/player/${encodeString(client.playerName)}`,
+                }}
+              />
+              <ListCell
+                label={client.clanName ?? ''}
+                href={
+                  client.clanName === null
+                    ? undefined
+                    : {
+                        pathname: `/clan/${encodeString(client.clanName)}`,
+                      }
+                }
+              />
+              <ListCell alignRight label={client.score.toString()} />
+            </>
+          ))}
+        </List>
+      </SnapshotTimeline>
     </main>
   );
 }

--- a/apps/frontend/components/SnapshotTimeline.tsx
+++ b/apps/frontend/components/SnapshotTimeline.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { Fragment, useEffect, useRef, useState } from 'react';
+import { format } from 'date-fns';
+import { List, ListCell } from './List';
+import { encodeString } from '../utils/encoding';
+import { useDebounce } from '../utils/hooks';
+
+export type TimelinePoint = {
+  id: number;
+  createdAt: string;
+  numClients: number;
+};
+
+type Snapshot = {
+  id: number;
+  createdAt: string;
+  name: string;
+  numClients: number;
+  maxClients: number;
+  map: {
+    name: string;
+    gameTypeName: string;
+  };
+  clients: {
+    playerName: string;
+    clanName: string | null;
+    score: number;
+  }[];
+};
+
+function sparklinePath(snapshots: TimelinePoint[]) {
+  const maxClients = Math.max(1, ...snapshots.map(({ numClients }) => numClients));
+
+  const points = snapshots.map(({ numClients }, index) => {
+    const x =
+      snapshots.length === 1
+        ? 1000
+        : (index / (snapshots.length - 1)) * 1000;
+    const y = 40 - (numClients / maxClients) * 36;
+    return `L${x},${y}`;
+  });
+
+  return `M0,40 ${points.join(' ')} L1000,40 Z`;
+}
+
+function SnapshotList({ snapshot }: { snapshot: Snapshot }) {
+  return (
+    <List
+      columns={[
+        {
+          title: '',
+          expand: false,
+        },
+        {
+          title: 'Name',
+          expand: true,
+        },
+        {
+          title: 'Clan',
+          expand: true,
+        },
+        {
+          title: 'Score',
+          expand: false,
+        },
+      ]}
+    >
+      {snapshot.clients.map((client, index) => (
+        <Fragment key={`${snapshot.id}-${client.playerName}`}>
+          <ListCell alignRight label={`${index + 1}`} />
+          <ListCell
+            label={client.playerName}
+            href={{
+              pathname: `/player/${encodeString(client.playerName)}`,
+            }}
+          />
+          <ListCell
+            label={client.clanName ?? ''}
+            href={
+              client.clanName === null
+                ? undefined
+                : {
+                    pathname: `/clan/${encodeString(client.clanName)}`,
+                  }
+            }
+          />
+          <ListCell alignRight label={client.score.toString()} />
+        </Fragment>
+      ))}
+    </List>
+  );
+}
+
+export function SnapshotTimeline({
+  snapshots,
+  apiPath,
+  children,
+}: {
+  snapshots: TimelinePoint[];
+  apiPath: string;
+  children: React.ReactNode;
+}) {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [lastLoaded, setLastLoaded] = useState<Snapshot | null>(null);
+  const cacheRef = useRef<Map<number, Snapshot>>();
+
+  if (cacheRef.current === undefined) {
+    cacheRef.current = new Map();
+  }
+
+  const cache = cacheRef.current;
+  const selected = selectedIndex === null ? null : snapshots[selectedIndex];
+  const debouncedSelected = useDebounce(selected, 150);
+  const snapshot =
+    selected === null ? null : cache.get(selected.id) ?? lastLoaded;
+
+  useEffect(() => {
+    if (debouncedSelected === null || cache.has(debouncedSelected.id)) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    (async () => {
+      try {
+        const response = await fetch(`${apiPath}/${debouncedSelected.id}`, {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const data: Snapshot = await response.json();
+        cache.set(data.id, data);
+        setLastLoaded(data);
+      } catch {
+        return;
+      }
+    })();
+
+    return () => {
+      controller.abort();
+    };
+  }, [debouncedSelected, apiPath, cache]);
+
+  if (snapshots.length === 0) {
+    return <>{children}</>;
+  }
+
+  const lastIndex = snapshots.length - 1;
+  const cursorFraction =
+    selectedIndex === null || lastIndex === 0 ? 1 : selectedIndex / lastIndex;
+  const stale = selected !== null && snapshot?.id !== selected.id;
+
+  return (
+    <>
+      <section className="flex flex-col gap-2 px-4 lg:px-8 xl:px-16">
+        <div className="flex flex-row items-baseline justify-between text-sm">
+          {selected === null ? (
+            <span>
+              <span className="font-bold text-[#970]">Live</span>
+              <span className="text-[#666]"> — drag the bar to rewind</span>
+            </span>
+          ) : (
+            <span>
+              <span className="font-bold text-[#970]">
+                {format(new Date(selected.createdAt), 'MMM d, HH:mm')}
+              </span>
+              <span className="text-[#666]">
+                {' '}
+                — {selected.numClients} clients
+                {!stale && snapshot !== null && ` on ${snapshot.map.name}`}
+              </span>
+            </span>
+          )}
+
+          {selected !== null && (
+            <button
+              onClick={() => setSelectedIndex(null)}
+              className="text-[#970] hover:underline"
+            >
+              Back to live
+            </button>
+          )}
+        </div>
+
+        <div className="relative h-10 border rounded-md overflow-hidden bg-[#fafafa]">
+          <svg
+            className="absolute inset-0 w-full h-full"
+            viewBox="0 0 1000 40"
+            preserveAspectRatio="none"
+          >
+            <path
+              d={sparklinePath(snapshots)}
+              fill="#997700"
+              fillOpacity="0.15"
+              stroke="#997700"
+              strokeOpacity="0.4"
+              strokeWidth="1"
+              vectorEffect="non-scaling-stroke"
+            />
+          </svg>
+
+          <div
+            className="absolute top-0 h-full w-0.5 -ml-px bg-[#970] pointer-events-none"
+            style={{
+              left: `${cursorFraction * 100}%`,
+            }}
+          />
+
+          <input
+            type="range"
+            min={0}
+            max={lastIndex}
+            step={1}
+            value={selectedIndex ?? lastIndex}
+            onChange={(event) => setSelectedIndex(Number(event.target.value))}
+            aria-label="Rewind to a past snapshot"
+            className="absolute inset-0 w-full h-full opacity-0 cursor-ew-resize"
+          />
+        </div>
+
+        <div className="flex flex-row justify-between text-xs text-[#666]">
+          <span suppressHydrationWarning>
+            {format(new Date(snapshots[0].createdAt), 'MMM d, HH:mm')}
+          </span>
+          <span>now</span>
+        </div>
+      </section>
+
+      {selected === null ? (
+        children
+      ) : snapshot === null ? (
+        <p className="text-center text-[#666]">Loading snapshot…</p>
+      ) : (
+        <div className={stale ? 'opacity-50 transition-opacity' : ''}>
+          <SnapshotList snapshot={snapshot} />
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/frontend/utils/hooks.ts
+++ b/apps/frontend/utils/hooks.ts
@@ -1,6 +1,21 @@
 import { useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { debounce } from "lodash";
 
 export function useSearchParamsObject() {
   const searchParams = useSearchParams();
   return Object.fromEntries(searchParams.entries());
+}
+
+export function useDebounce<T>(value: T, wait: number): T {
+  const [debounced, setDebounced] = useState(value);
+  const setDebouncedSlowly = useMemo(() => debounce(setDebounced, wait), [wait]);
+
+  useEffect(() => {
+    setDebouncedSlowly(value);
+  }, [value, setDebouncedSlowly]);
+
+  useEffect(() => () => setDebouncedSlowly.cancel(), [setDebouncedSlowly]);
+
+  return debounced;
 }


### PR DESCRIPTION
## What

The server page now shows a draggable timeline above the player list, covering the ~48h of snapshots kept in the database (5-minute polling → up to ~576 snapshots per server). Dragging the cursor (or clicking, touch, arrow keys) loads the player list as it was at that moment; a player-count sparkline gives the bar shape. A "Back to live" link restores the live view.


## How

- **Loaded with the page:** only timeline metadata (`id`, `createdAt`, `numClients` per snapshot, a few KB) — enough to draw the bar and snap the cursor instantly. Loading all snapshots with clients upfront would be ~35k rows for data mostly never viewed.
- **Loaded while dragging:** the selected snapshot's clients, via a new `GET /api/server/[ip]/[port]/snapshot/[snapshotId]` route. Fetches are debounced (150ms) so sweeping the bar only fetches where the cursor settles, in-flight requests are aborted when the cursor moves on, and results are cached in memory per snapshot id. Snapshots are immutable, so the route also serves `Cache-Control: public, max-age=86400, immutable`.
- The displayed snapshot is derived from the cache at render time, so revisiting an already-seen position renders instantly with zero network requests.
- Adds a shared `useDebounce(value, wait)` hook to `utils/hooks.ts`, built on lodash's `debounce`.

Cursor positions are index-based rather than time-proportional, so gaps where the server was unreachable are compressed — a fair trade-off with uniform 5-minute polling.

## Testing

- Verified end to end with Playwright against a seeded database (576 snapshots / ~3.9k client rows over 48h): dragging loads the right snapshot, empty snapshots render an empty list, revisits issue no requests, "Back to live" works.
- API returns 200 with cache headers, 404 for snapshots not belonging to the server, 400 for malformed ids.
- Type check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
