### PR TITLE
Remove Google Analytics

### DIFF
--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -6,10 +6,7 @@ import { HeaderTabs } from '../components/HeaderTabs';
 import prisma from '../utils/prisma';
 import { SearchForm } from '../components/SearchForm';
 import packageJson from 'package.json';
-import { GoogleAnalytics } from '@next/third-parties/google';
 import { Suspense } from 'react';
-
-const gaId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
 
 export const metadata = {
   title: 'Welcome to Teerank',
@@ -123,7 +120,6 @@ export default async function RootLayout({
           </Link>
         </footer>
       </body>
-      {gaId !== undefined && <GoogleAnalytics gaId={gaId} />}
     </html>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@aws-sdk/client-s3": "^3.1106.0",
         "@fastify/autoload": "~5.7.1",
         "@fastify/sensible": "~5.2.0",
-        "@next/third-parties": "^14.1.0",
         "@prisma/client": "^5.22.0",
         "@sentry/nextjs": "^7.107.0",
         "@sentry/node": "^7.120.2",
@@ -4104,18 +4103,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@next/third-parties": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-14.1.0.tgz",
-      "integrity": "sha512-f55SdvQ1WWxi4mb5QqtYQh5wRzbm1XaeP7s39DPn4ks3re+n9VlFccbMxBRHqkE62zAyIKmvkUB2cByT/gugGA==",
-      "dependencies": {
-        "third-party-capital": "1.0.20"
-      },
-      "peerDependencies": {
-        "next": "^13.0.0 || ^14.0.0",
-        "react": "^18.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -19806,11 +19793,6 @@
       "peerDependencies": {
         "tslib": "^2"
       }
-    },
-    "node_modules/third-party-capital": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
-      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA=="
     },
     "node_modules/thread-stream": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@aws-sdk/client-s3": "^3.1106.0",
     "@fastify/autoload": "~5.7.1",
     "@fastify/sensible": "~5.2.0",
-    "@next/third-parties": "^14.1.0",
     "@prisma/client": "^5.22.0",
     "@sentry/nextjs": "^7.107.0",
     "@sentry/node": "^7.120.2",


### PR DESCRIPTION
Removes the `GoogleAnalytics` component from the root layout, along with the `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID` env var it read and the now-unused `@next/third-parties` dependency. Cloudflare Web Analytics will take over, which needs no code change when enabled with automatic beacon injection on a proxied domain.

Note: `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID` isn't set anywhere in the repo, so nothing else needed cleaning up — but it can be deleted from the Fly app secrets/env if it's set there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)