### PR TITLE
Show past members' current clan and keep clan list filters on one line

### DIFF
--- a/apps/frontend/app/clan/[clanName]/page.tsx
+++ b/apps/frontend/app/clan/[clanName]/page.tsx
@@ -157,7 +157,7 @@ export default async function Index({
         players={clan.clanPlayerInfos.map((playerInfo, index) => ({
           rank: index + 1,
           name: playerInfo.player.name,
-          clan: clanName,
+          clan: playerInfo.player.clanName ?? undefined,
           isActiveClan: playerInfo.player.clanName === clanName,
           playTime: playerInfo.playTime,
           lastSeenAt: playerInfo.player.lastSeenAt,

--- a/apps/frontend/components/PlayerList.tsx
+++ b/apps/frontend/components/PlayerList.tsx
@@ -43,7 +43,7 @@ export function PlayerList({
     },
     {
       title: (
-        <>
+        <span className="flex flex-row items-center gap-2 whitespace-nowrap">
           Name
           <Suspense>
             <EyeToggle
@@ -52,7 +52,7 @@ export function PlayerList({
               param="shared"
               value="hidden"
               visibleWhenSet={false}
-              className="ml-3"
+              className="ml-1"
             />
             {showInactiveToggle && (
               <EyeToggle
@@ -61,11 +61,10 @@ export function PlayerList({
                 param="past"
                 value="true"
                 visibleWhenSet={true}
-                className="ml-2"
               />
             )}
           </Suspense>
-        </>
+        </span>
       ),
       expand: true,
     },


### PR DESCRIPTION
On the clan player list, every row was labelled with the clan whose page you were viewing, so inactive ("Past") members looked like they were still in it. Rows now show the player's actual current clan, and are left blank if the player is clanless.

The "shared" and "inactive" eye toggles in the `Name` column header also wrapped onto a second line; the header is now a nowrap flex row so they stay inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)