### PR TITLE
Reflect the rewound snapshot in the server page header

### DIFF
--- a/apps/frontend/app/server/[ip]/[port]/page.tsx
+++ b/apps/frontend/app/server/[ip]/[port]/page.tsx
@@ -2,13 +2,14 @@ import { paramsSchema } from './schema';
 import { z } from 'zod';
 import { notFound } from 'next/navigation';
 import { isIP } from 'net';
-import Link from 'next/link';
 import Image from 'next/image';
 import { List, ListCell } from '../../../../components/List';
 import { searchParamPageSchema } from '../../../../utils/page';
 import prisma from '../../../../utils/prisma';
 import { encodeIp, encodeString } from '../../../../utils/encoding';
 import { SnapshotTimeline } from '../../../../components/SnapshotTimeline';
+import { SnapshotProvider } from '../../../../components/SnapshotContext';
+import { ServerHeaderInfo } from '../../../../components/ServerHeaderInfo';
 import { formatPlayTime } from '../../../../utils/format';
 import { GameServer } from '@prisma/client';
 import { formatDuration, intervalToDuration } from 'date-fns';
@@ -141,52 +142,7 @@ export default async function Index({
 
   return (
     <main className="flex flex-col gap-8 py-12">
-      <header className="px-8 xl:px-20">
-        <ActivityHeader
-          apiPath={`/api/server/${encodeIp(gameServer.ip)}/${gameServer.port}/activity`}
-          activity={activity}
-          contentClassName="flex-row items-center gap-4"
-        >
-          <Image src="/server.png" width={124} height={100} alt="Server" />
-          <section className="flex flex-col gap-2">
-            <h1 className="text-2xl font-bold">
-              {gameServer.gameServerState.name}
-            </h1>
-            <div className="flex flex-row divide-x">
-              <span className="pr-4">
-                <Link
-                  className="hover:underline"
-                  href={{
-                    pathname: `/gametype/${encodeString(
-                      gameServer.gameServerState.map.gameTypeName
-                    )}`,
-                  }}
-                >
-                  {gameServer.gameServerState.map.gameTypeName}
-                </Link>
-              </span>
-              <span className="px-4">
-                <Link
-                  className="hover:underline"
-                  href={{
-                    pathname: `/gametype/${encodeString(
-                      gameServer.gameServerState.map.gameTypeName
-                    )}/map/${encodeString(gameServer.gameServerState.map.name)}`,
-                  }}
-                >
-                  {gameServer.gameServerState.map.name}
-                </Link>
-              </span>
-              <span className="px-4">{`${gameServer.gameServerState.numClients} / ${gameServer.gameServerState.maxClients} clients`}</span>
-              <span className="px-4">
-                Playtime: {formatPlayTime(gameServer.playTime)}
-              </span>
-            </div>
-          </section>
-        </ActivityHeader>
-      </header>
-
-      <SnapshotTimeline
+      <SnapshotProvider
         snapshots={snapshots.map((snapshot) => ({
           id: snapshot.id,
           createdAt: snapshot.createdAt.toISOString(),
@@ -196,51 +152,73 @@ export default async function Index({
           gameServer.port
         }/snapshot`}
       >
-        <List
-          pageCount={Math.ceil(gameServer.gameServerState._count.clients / 100)}
-          columns={[
-            {
-              title: '',
-              expand: false,
-            },
-            {
-              title: 'Name',
-              expand: true,
-            },
-            {
-              title: 'Clan',
-              expand: true,
-            },
-            {
-              title: 'Score',
-              expand: false,
-            },
-          ]}
-        >
-          {gameServer.gameServerState.clients.map((client, index) => (
-            <>
-              <ListCell alignRight label={`${index + 1}`} />
-              <ListCell
-                label={client.playerName}
-                href={{
-                  pathname: `/player/${encodeString(client.playerName)}`,
-                }}
-              />
-              <ListCell
-                label={client.clanName ?? ''}
-                href={
-                  client.clanName === null
-                    ? undefined
-                    : {
-                        pathname: `/clan/${encodeString(client.clanName)}`,
-                      }
-                }
-              />
-              <ListCell alignRight label={client.score.toString()} />
-            </>
-          ))}
-        </List>
-      </SnapshotTimeline>
+        <header className="px-8 xl:px-20">
+          <ActivityHeader
+            apiPath={`/api/server/${encodeIp(gameServer.ip)}/${gameServer.port}/activity`}
+            activity={activity}
+            contentClassName="flex-row items-center gap-4"
+          >
+            <Image src="/server.png" width={124} height={100} alt="Server" />
+            <ServerHeaderInfo
+              name={gameServer.gameServerState.name}
+              gameTypeName={gameServer.gameServerState.map.gameTypeName}
+              mapName={gameServer.gameServerState.map.name}
+              numClients={gameServer.gameServerState.numClients}
+              maxClients={gameServer.gameServerState.maxClients}
+              playTime={formatPlayTime(gameServer.playTime)}
+            />
+          </ActivityHeader>
+        </header>
+
+        <SnapshotTimeline>
+          <List
+            pageCount={Math.ceil(
+              gameServer.gameServerState._count.clients / 100
+            )}
+            columns={[
+              {
+                title: '',
+                expand: false,
+              },
+              {
+                title: 'Name',
+                expand: true,
+              },
+              {
+                title: 'Clan',
+                expand: true,
+              },
+              {
+                title: 'Score',
+                expand: false,
+              },
+            ]}
+          >
+            {gameServer.gameServerState.clients.map((client, index) => (
+              <>
+                <ListCell alignRight label={`${index + 1}`} />
+                <ListCell
+                  label={client.playerName}
+                  href={{
+                    pathname: `/player/${encodeString(client.playerName)}`,
+                  }}
+                />
+                <ListCell
+                  label={client.clanName ?? ''}
+                  href={
+                    client.clanName === null
+                      ? undefined
+                      : {
+                          pathname: `/clan/${encodeString(client.clanName)}`,
+                        }
+                  }
+                />
+                <ListCell alignRight label={client.score.toString()} />
+              </>
+            ))}
+          </List>
+        </SnapshotTimeline>
+      </SnapshotProvider>
     </main>
   );
 }

--- a/apps/frontend/components/ServerHeaderInfo.tsx
+++ b/apps/frontend/components/ServerHeaderInfo.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Link from 'next/link';
+import { encodeString } from '../utils/encoding';
+import { useSnapshot } from './SnapshotContext';
+
+export function ServerHeaderInfo({
+  name,
+  gameTypeName,
+  mapName,
+  numClients,
+  maxClients,
+  playTime,
+}: {
+  name: string;
+  gameTypeName: string;
+  mapName: string;
+  numClients: number;
+  maxClients: number;
+  playTime: string;
+}) {
+  const { selected, snapshot } = useSnapshot();
+  const rewound = selected === null ? null : snapshot;
+
+  const displayed =
+    rewound === null
+      ? { name, gameTypeName, mapName, numClients, maxClients }
+      : {
+          name: rewound.name,
+          gameTypeName: rewound.map.gameTypeName,
+          mapName: rewound.map.name,
+          numClients: rewound.numClients,
+          maxClients: rewound.maxClients,
+        };
+
+  return (
+    <section className="flex flex-col gap-2">
+      <h1 className="text-2xl font-bold">{displayed.name}</h1>
+      <div className="flex flex-row divide-x">
+        <span className="pr-4">
+          <Link
+            className="hover:underline"
+            href={{
+              pathname: `/gametype/${encodeString(displayed.gameTypeName)}`,
+            }}
+          >
+            {displayed.gameTypeName}
+          </Link>
+        </span>
+        <span className="px-4">
+          <Link
+            className="hover:underline"
+            href={{
+              pathname: `/gametype/${encodeString(
+                displayed.gameTypeName
+              )}/map/${encodeString(displayed.mapName)}`,
+            }}
+          >
+            {displayed.mapName}
+          </Link>
+        </span>
+        <span className="px-4">{`${displayed.numClients} / ${displayed.maxClients} clients`}</span>
+        <span className="px-4">Playtime: {playTime}</span>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/components/SnapshotContext.tsx
+++ b/apps/frontend/components/SnapshotContext.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useDebounce } from '../utils/hooks';
+
+export type TimelinePoint = {
+  id: number;
+  createdAt: string;
+  numClients: number;
+};
+
+export type Snapshot = {
+  id: number;
+  createdAt: string;
+  name: string;
+  numClients: number;
+  maxClients: number;
+  map: {
+    name: string;
+    gameTypeName: string;
+  };
+  clients: {
+    playerName: string;
+    clanName: string | null;
+    score: number;
+  }[];
+};
+
+type SnapshotContextValue = {
+  snapshots: TimelinePoint[];
+  selectedIndex: number | null;
+  setSelectedIndex: (index: number | null) => void;
+  selected: TimelinePoint | null;
+  snapshot: Snapshot | null;
+  stale: boolean;
+};
+
+const SnapshotContext = createContext<SnapshotContextValue>({
+  snapshots: [],
+  selectedIndex: null,
+  setSelectedIndex: () => undefined,
+  selected: null,
+  snapshot: null,
+  stale: false,
+});
+
+export function useSnapshot() {
+  return useContext(SnapshotContext);
+}
+
+export function SnapshotProvider({
+  snapshots,
+  apiPath,
+  children,
+}: {
+  snapshots: TimelinePoint[];
+  apiPath: string;
+  children: React.ReactNode;
+}) {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [lastLoaded, setLastLoaded] = useState<Snapshot | null>(null);
+  const cacheRef = useRef<Map<number, Snapshot>>();
+
+  if (cacheRef.current === undefined) {
+    cacheRef.current = new Map();
+  }
+
+  const cache = cacheRef.current;
+  const selected = selectedIndex === null ? null : snapshots[selectedIndex];
+  const debouncedSelected = useDebounce(selected, 150);
+  const snapshot =
+    selected === null ? null : cache.get(selected.id) ?? lastLoaded;
+
+  useEffect(() => {
+    if (debouncedSelected === null || cache.has(debouncedSelected.id)) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    (async () => {
+      try {
+        const response = await fetch(`${apiPath}/${debouncedSelected.id}`, {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const data: Snapshot = await response.json();
+        cache.set(data.id, data);
+        setLastLoaded(data);
+      } catch {
+        return;
+      }
+    })();
+
+    return () => {
+      controller.abort();
+    };
+  }, [debouncedSelected, apiPath, cache]);
+
+  const value = useMemo(
+    () => ({
+      snapshots,
+      selectedIndex,
+      setSelectedIndex,
+      selected,
+      snapshot,
+      stale: selected !== null && snapshot?.id !== selected.id,
+    }),
+    [snapshots, selectedIndex, selected, snapshot]
+  );
+
+  return (
+    <SnapshotContext.Provider value={value}>
+      {children}
+    </SnapshotContext.Provider>
+  );
+}

--- a/apps/frontend/components/SnapshotTimeline.tsx
+++ b/apps/frontend/components/SnapshotTimeline.tsx
@@ -1,33 +1,10 @@
 'use client';
 
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment } from 'react';
 import { format } from 'date-fns';
 import { List, ListCell } from './List';
 import { encodeString } from '../utils/encoding';
-import { useDebounce } from '../utils/hooks';
-
-export type TimelinePoint = {
-  id: number;
-  createdAt: string;
-  numClients: number;
-};
-
-type Snapshot = {
-  id: number;
-  createdAt: string;
-  name: string;
-  numClients: number;
-  maxClients: number;
-  map: {
-    name: string;
-    gameTypeName: string;
-  };
-  clients: {
-    playerName: string;
-    clanName: string | null;
-    score: number;
-  }[];
-};
+import { Snapshot, TimelinePoint, useSnapshot } from './SnapshotContext';
 
 function sparklinePath(snapshots: TimelinePoint[]) {
   const maxClients = Math.max(1, ...snapshots.map(({ numClients }) => numClients));
@@ -92,58 +69,15 @@ function SnapshotList({ snapshot }: { snapshot: Snapshot }) {
   );
 }
 
-export function SnapshotTimeline({
-  snapshots,
-  apiPath,
-  children,
-}: {
-  snapshots: TimelinePoint[];
-  apiPath: string;
-  children: React.ReactNode;
-}) {
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-  const [lastLoaded, setLastLoaded] = useState<Snapshot | null>(null);
-  const cacheRef = useRef<Map<number, Snapshot>>();
-
-  if (cacheRef.current === undefined) {
-    cacheRef.current = new Map();
-  }
-
-  const cache = cacheRef.current;
-  const selected = selectedIndex === null ? null : snapshots[selectedIndex];
-  const debouncedSelected = useDebounce(selected, 150);
-  const snapshot =
-    selected === null ? null : cache.get(selected.id) ?? lastLoaded;
-
-  useEffect(() => {
-    if (debouncedSelected === null || cache.has(debouncedSelected.id)) {
-      return;
-    }
-
-    const controller = new AbortController();
-
-    (async () => {
-      try {
-        const response = await fetch(`${apiPath}/${debouncedSelected.id}`, {
-          signal: controller.signal,
-        });
-
-        if (!response.ok) {
-          return;
-        }
-
-        const data: Snapshot = await response.json();
-        cache.set(data.id, data);
-        setLastLoaded(data);
-      } catch {
-        return;
-      }
-    })();
-
-    return () => {
-      controller.abort();
-    };
-  }, [debouncedSelected, apiPath, cache]);
+export function SnapshotTimeline({ children }: { children: React.ReactNode }) {
+  const {
+    snapshots,
+    selectedIndex,
+    setSelectedIndex,
+    selected,
+    snapshot,
+    stale,
+  } = useSnapshot();
 
   if (snapshots.length === 0) {
     return <>{children}</>;
@@ -152,29 +86,16 @@ export function SnapshotTimeline({
   const lastIndex = snapshots.length - 1;
   const cursorFraction =
     selectedIndex === null || lastIndex === 0 ? 1 : selectedIndex / lastIndex;
-  const stale = selected !== null && snapshot?.id !== selected.id;
 
   return (
     <>
       <section className="flex flex-col gap-2 px-4 lg:px-8 xl:px-16">
         <div className="flex flex-row items-baseline justify-between text-sm">
-          {selected === null ? (
-            <span>
-              <span className="font-bold text-[#970]">Live</span>
-              <span className="text-[#666]"> — drag the bar to rewind</span>
-            </span>
-          ) : (
-            <span>
-              <span className="font-bold text-[#970]">
-                {format(new Date(selected.createdAt), 'MMM d, HH:mm')}
-              </span>
-              <span className="text-[#666]">
-                {' '}
-                — {selected.numClients} clients
-                {!stale && snapshot !== null && ` on ${snapshot.map.name}`}
-              </span>
-            </span>
-          )}
+          <span className="font-bold text-[#970]">
+            {selected === null
+              ? 'Live'
+              : format(new Date(selected.createdAt), 'MMM d, HH:mm')}
+          </span>
 
           {selected !== null && (
             <button


### PR DESCRIPTION
The rewind bar's label repeated information that belongs in the page header, so this moves it there: dragging the bar now updates the header's server name, gametype, map and client count to the selected snapshot, while the label itself is reduced to just `Live` or the snapshot timestamp.

To make that possible, the timeline's state (selected index, snapshot fetching and caching) moves out of `SnapshotTimeline` into a new `SnapshotProvider` context that wraps both the header and the timeline, and the header's detail row becomes a `ServerHeaderInfo` client component reading from it. Playtime stays the server-level value, and while a newly dragged snapshot loads the header keeps showing the last loaded one, matching the list's existing stale-opacity behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)